### PR TITLE
Create group with user

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you like to add a method (or tweak something), please open a pull-request. We
 But we also love solving issues, so in case you don't really have the time for a pull-request right now,
 maybe you can [just tell us what you'd like](https://github.com/Cimpress/coam-client/issues)? 
 
-Or maybe you just feel like [writting us a mail](mailto:TrdelnikSquad@cimpress.io)? Yes, you guessed right, we also love reading mails ;) 
+Or maybe you just feel like [writing us a mail](mailto:TrdelnikSquad@cimpress.io)? Yes, you guessed right, we also love reading mails ;) 
 
 
 #### CoamClient class
@@ -45,6 +45,7 @@ by the `options` parameter passed in the constructor.
 * addResourceToGroup(groupId, resourceType, resourceId)
 * getUserPermissionsForResourceType(principal, resourceType)
 * getUsersWithPermission(resourceType, resourceIdentifier, permission)
+* createGroupWithUser(principalToCreateGroup, principalToAddToGroup, groupName, groupDescription, rolesToAdd, resourcesToAdd)
 
 #### Direct helper functions
 In some cases, it is easier to simply call a function to perform the required action
@@ -72,5 +73,6 @@ Here is a list of helpers (name + required parameters):
 * **addResourceToGroup** (accessToken, groupId, resourceType, resourceId) 
 * **getUserPermissionsForResourceType** (accessToken, principal, resourceType)
 * **getUsersWithPermission** (accessToken, resourceType, resourceIdentifier, permission)
+* **createGroupWithUser** (accessToken, principalToCreateGroup, principalToAddToGroup, groupName, groupDescription, rolesToAdd, resourcesToAdd)
 
 **Important**: All helper methods are using the CoamClient class with default settings (see above).  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A thin client for COAM service",
   "main": "./lib/index.js",
   "files": [

--- a/src/coamHelpers.js
+++ b/src/coamHelpers.js
@@ -142,6 +142,13 @@ const getUsersWithPermission = (accessToken, resourceType, resourceIdentifier, p
     return client.getUsersWithPermission(resourceType, resourceIdentifier, permission);
 };
 
+const createGroupWithUser = (accessToken, principalToCreateGroup, principalToAddToGroup, groupName, groupDescription, rolesToAdd, resourcesToAdd) => {
+    const client = new CoamClient({
+        accessToken: accessToken,
+    });
+    return client.createGroupWithUser(principalToCreateGroup, principalToAddToGroup, groupName, groupDescription, rolesToAdd, resourcesToAdd);
+};
+
 module.exports = {
     getRoles,
 
@@ -171,4 +178,6 @@ module.exports = {
     getPrincipal,
 
     getUsersWithPermission,
+
+    createGroupWithUser,
 };

--- a/tests/CoamClient.tests.js
+++ b/tests/CoamClient.tests.js
@@ -304,36 +304,36 @@ describe('CoamClient', function() {
 
     it('createGroup', async function() {
         let newGroupDescription = {
-            "name": "string",
-            "description": "string",
-            "id": "123",
-            "created_by": "string",
-            "created_at": "2019-02-06T08:02:09.419Z",
-            "members": [
+            'name': 'string',
+            'description': 'string',
+            'id': '123',
+            'created_by': 'string',
+            'created_at': '2019-02-06T08:02:09.419Z',
+            'members': [
                 {
-                    "is_admin": true,
-                    "principal": "string",
-                    "roles": [
-                        "string"
-                    ]
-                }
+                    'is_admin': true,
+                    'principal': 'string',
+                    'roles': [
+                        'string',
             ],
-            "resources": [
+                },
+            ],
+            'resources': [
                 {
-                    "resource_type": "string",
-                    "resource_identifier": "string"
-                }
+                    'resource_type': 'string',
+                    'resource_identifier': 'string',
+                },
             ],
-            "permissions": {
-                "additionalProp1": [
+            'permissions': {
+                'additionalProp1': [
                     {
-                        "identifier": "string",
-                        "permissions": [
-                            "string"
-                        ]
-                    }
+                        'identifier': 'string',
+                        'permissions': [
+                            'string',
                 ],
-            }
+                    },
+                ],
+            },
         };
         let requestStub = mockRequestResponse(newGroupDescription);
 
@@ -341,7 +341,7 @@ describe('CoamClient', function() {
 
         let result = await client.createGroup('name', 'desc');
 
-        expect(result).to.deep.equal(newGroupDescription)
+        expect(result).to.deep.equal(newGroupDescription);
 
         calledOnceWith(requestStub, {
             'headers': {


### PR DESCRIPTION
Shortcuts a typical need for services that want to create a new COAM group, add another user, assign roles and resources, and removes the service user itself.