### PR TITLE
Avoid timeout on COAM call by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ by the `options` parameter passed in the constructor.
 * _retryOnForbidden_ - A flag specifying if a retry has to be performed in case of 'Forbidden' response. Defaults to 'true'
 * _debugFunction_ - A function to call to provide debug information. Defaults to none.
 * _errorFunction_ - A function to call on error. Defaults to console.err;
+* _timeout_ - A value setting the timeout of the underlying HTTP calls to COAM. Defaults to 0 (= no timeout).
 
 ###### Provided methods 
 * hasPermission(principal, resourceType, resourceIdentifier, permission)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ by the `options` parameter passed in the constructor.
 * _retryOnForbidden_ - A flag specifying if a retry has to be performed in case of 'Forbidden' response. Defaults to 'true'
 * _debugFunction_ - A function to call to provide debug information. Defaults to none.
 * _errorFunction_ - A function to call on error. Defaults to console.err;
-* _timeout_ - A value setting the timeout of the underlying HTTP calls to COAM. Defaults to 0 (= no timeout).
+* _timeout_ - A value setting the timeout of the underlying HTTP calls to COAM. Defaults to 10000 (10 seconds). Set it to 0 for no timeout.
 
 ###### Provided methods 
 * hasPermission(principal, resourceType, resourceIdentifier, permission)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A thin client for COAM service",
   "main": "./lib/index.js",
   "files": [

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -8,7 +8,7 @@ class CoamClient {
     constructor(options) {
         let opts = options || {};
         this.baseUrl = opts.baseUrl || DEFAULT_BASE_URL;
-        this.timeout = opts.timeout || 0;
+        this.timeout = opts.timeout || 10000;
         this.accessToken = opts.accessToken || undefined;
         this.retryAttempts = opts.retryAttempts || 2;
         this.retryDelayInMs = opts.retryDelayInMs || 200;

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -8,7 +8,7 @@ class CoamClient {
     constructor(options) {
         let opts = options || {};
         this.baseUrl = opts.baseUrl || DEFAULT_BASE_URL;
-        this.timeout = opts.timeout || 1000;
+        this.timeout = opts.timeout || 0;
         this.accessToken = opts.accessToken || undefined;
         this.retryAttempts = opts.retryAttempts || 2;
         this.retryDelayInMs = opts.retryDelayInMs || 200;


### PR DESCRIPTION
I ran into a situation when the COAM call took over 1 second (I think I initiated a lot of calls in parallel). I want to avoid my client call to fail.

I'm suggesting the default values shouldn't come with a timeout, at least not such a short one. It took me a while where the 1 second timeout comes from.