### PR TITLE
Update getUsersWithPermission function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.14] - 2019.06.18
+### Changed
+- Allow getUsersWithPermission to be called with an undefined resourceIdentifier, as this parameter is now optional in the COAM API
+
 ## [0.1.13] - 2019.06.06
 ### Changed
 - Downgrade axios until a fix for axios-retry is avaialble

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A thin client for COAM service",
   "main": "./lib/index.js",
   "files": [

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -406,7 +406,7 @@ class CoamClient {
     }
 
     getUsersWithPermission(resourceType, resourceIdentifier, permission) {
-        let url = this.__buildUrl(`/auth/access-management/v1/search/canonicalPrincipals/byPermission?resource_type={{resourceType}}&resource_identifier={{resourceIdentifier}}&permission={{permission}}`, {
+        let url = this.__buildUrl(`/auth/access-management/v1/search/canonicalPrincipals/byPermission?resource_type={{resourceType}}${resourceIdentifier ? '&resource_identifier={{resourceIdentifier}}' : ''}&permission={{permission}}`, {
             resourceType,
             resourceIdentifier,
             permission,

--- a/tests/CoamClient.tests.js
+++ b/tests/CoamClient.tests.js
@@ -58,14 +58,14 @@ describe('CoamClient', function() {
         requestStub = mockRequestResponse('yes!');
     });
 
-    it("buildGroupUrlFromId", function() {
-      const baseUrl = "https://www.example.com";
-      const client = new CoamClient({ baseUrl });
-      const groupId = 12345;
+    it('buildGroupUrlFromId', function() {
+        const baseUrl = 'https://www.example.com';
+        const client = new CoamClient({baseUrl});
+        const groupId = 12345;
 
-      const actual = client.buildGroupUrlFromId(groupId);
+        const actual = client.buildGroupUrlFromId(groupId);
 
-      expect(actual).to.equal(`${baseUrl}/auth/access-management/v1/groups/${groupId}`);
+        expect(actual).to.equal(`${baseUrl}/auth/access-management/v1/groups/${groupId}`);
     });
 
     it('getGroupInfo', async function() {
@@ -467,16 +467,29 @@ describe('CoamClient', function() {
     });
 
     it('getUsersWithPermission', async function() {
-        const client = new CoamClient({accessToken: accessToken});
+        let client = new CoamClient({accessToken: accessToken});
 
+        // Works when specifying resourceIdentifier
         await client.getUsersWithPermission(resourceType, resourceIdentifier, permission);
-
         calledOnceWith(requestStub, {
             'headers': {
                 'Authorization': `Bearer ${accessToken}`,
             },
             'method': 'GET',
             'url': `/auth/access-management/v1/search/canonicalPrincipals/byPermission?resource_type=${resourceType}&resource_identifier=${resourceIdentifier}&permission=${permission}`,
+        });
+
+        // Works without specifying resourceIdentifier
+        requestStub = mockRequestResponse('yes!');
+        client = new CoamClient({accessToken: accessToken});
+        await client.getUsersWithPermission(resourceType, undefined, permission);
+
+        calledOnceWith(requestStub, {
+            'headers': {
+                'Authorization': `Bearer ${accessToken}`,
+            },
+            'method': 'GET',
+            'url': `/auth/access-management/v1/search/canonicalPrincipals/byPermission?resource_type=${resourceType}&permission=${permission}`,
         });
     });
 


### PR DESCRIPTION
Allows the getUsersWithPermission function to work with an undefined resoucceIdentifier
being specified (https://cimpress-support.atlassian.net/browse/AMD-1132). This is trying to model an "optional" parameter within the existing function, but maybe it'd be better to add another function?