### PR TITLE
Return nicer error from axios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.15] - 2019.07.24
+### Changed
+- Wrap axios errors to avoid logging the http client's buffer.
+
 ## [0.1.14] - 2019.06.18
 ### Changed
 - Allow getUsersWithPermission to be called with an undefined resourceIdentifier, as this parameter is now optional in the COAM API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A thin client for COAM service",
   "main": "./lib/index.js",
   "files": [

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -34,6 +34,14 @@ class CoamClient {
             baseURL: this.baseUrl,
             timeout: this.timeout,
         });
+        this.instance.interceptors.response.use((response) => response, (error) => {
+            let newError = error && error.response && {
+                data: error.response.data,
+                status: error.response.status,
+                headers: error.response.headers,
+            } || error.message && {message: error.message, code: error.code, stack: error.stack} || error;
+            throw newError;
+        });
 
         if (this.retryAttempts > 0) {
             axiosRetry(this.instance, {

--- a/tests/CoamClient.tests.js
+++ b/tests/CoamClient.tests.js
@@ -42,6 +42,11 @@ function mockRequestResponse(resolveWith) {
     fakeAxios = {
         create: sinon.stub().returns({
             request: requestStub,
+            interceptors: {
+                response: {
+                    use() {},
+                },
+            },
         }),
     };
     CoamClient.__set__('axios', fakeAxios);


### PR DESCRIPTION
Axios error messages include a dump of the http client, that is, all the buffer that's in axios.

Unless there's an easier solution for that, I'm suggesting to just return the relevant parts of the error.