### PR TITLE
hasPermission should throw an error on errors other than 404

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.1.16",
+  "version": "0.2.0",
   "description": "A thin client for COAM service",
   "main": "./lib/index.js",
   "files": [

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -127,8 +127,14 @@ class CoamClient {
         return this.__exec(data)
             .then(() => Promise.resolve(true))
             .catch((e) => {
-                this.__logError(this.logPrefix, e);
-                return Promise.resolve(false);
+                // COAM returns a 404 if the principal does not have access to a resource
+                if (e.status === 404) {
+                    return false;
+                }
+
+                // for all other errors, we want to throw an exception so that clients
+                // can retry instead of assuming the user does not have access
+                throw e;
             });
     }
 

--- a/tests/CoamClient.tests.js
+++ b/tests/CoamClient.tests.js
@@ -90,10 +90,12 @@ describe('CoamClient', function() {
         });
     });
 
-    it('hasPermission', async function() {
+    it('hasPermission - success', async function() {
+        requestStub = mockRequestResponse(Promise.resolve());
         const client = new CoamClient({accessToken: accessToken});
 
-        await client.hasPermission(principal, resourceType, resourceIdentifier, permission);
+        let result = await client.hasPermission(principal, resourceType, resourceIdentifier, permission);
+        expect(result).to.be.true;
 
         calledOnceWith(requestStub, {
             'headers': {
@@ -104,6 +106,27 @@ describe('CoamClient', function() {
             },
             'url': `/auth/access-management/v1/principals/${encodeURIComponent(principal)}/permissions/${encodeURIComponent(resourceType)}/${encodeURIComponent(resourceIdentifier)}/${encodeURIComponent(permission)}`,
         });
+    });
+
+    it('hasPermission - success 404', async function() {
+        requestStub = mockRequestResponse(Promise.reject({status: 404}));
+        const client = new CoamClient({accessToken: accessToken});
+
+        let result = await client.hasPermission(principal, resourceType, resourceIdentifier, permission);
+        expect(result).to.be.false;
+    });
+
+    it('hasPermission - other error', async function() {
+        requestStub = mockRequestResponse(Promise.reject({status: 500}));
+        const client = new CoamClient({accessToken: accessToken});
+
+        let err = undefined;
+        try {
+            await client.hasPermission(principal, resourceType, resourceIdentifier, permission);
+        } catch (errFromCall) {
+            err = errFromCall;
+        }
+        expect(err).to.not.be.undefined;
     });
 
     it('grantRoleToPrincipal', async function() {


### PR DESCRIPTION
When the call to COAM fails, `hasPermission` should fail (= throw an exception). Returning false makes it unclear whether there was a network error, a 500 or just the 404 that COAM returns when the user does not have permissions.

If you want to test this change locally, here's good example code:

```javascript
(async () => {
    const CoamClient = require('./src/CoamClient');

    const options = {
        accessToken: '<valid JWT>',
        baseUrl: 'http://localhost:8080',
    };
    const client = new CoamClient(options);

    try {
        let result = await client.hasPermission('youremail@cimpress.com', 'resource-type', 'foobar', 'read');
        console.log('it worked: ' + result);
    } catch (err) {
        console.log('it did not work');
        console.log(err);
    }
})();
```

Closes #20 