### PR TITLE
Allow to pass in 0 as an option, especially for the retry attempts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.1.16",
+  "version": "0.2.2",
   "description": "A thin client for COAM service",
   "main": "./lib/index.js",
   "files": [

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -8,10 +8,10 @@ class CoamClient {
     constructor(options) {
         let opts = options || {};
         this.baseUrl = opts.baseUrl || DEFAULT_BASE_URL;
-        this.timeout = opts.timeout || 10000;
+        this.timeout = Number.isInteger(opts.timeout) ? opts.timeout : 10000;
         this.accessToken = opts.accessToken || undefined;
-        this.retryAttempts = opts.retryAttempts || 2;
-        this.retryDelayInMs = opts.retryDelayInMs || 200;
+        this.retryAttempts = Number.isInteger(opts.retryAttempts) ? opts.retryAttempts : 2;
+        this.retryDelayInMs = Number.isInteger(opts.retryDelayInMs) ? opts.retryDelayInMs : 200;
         this.retryOnForbidden = 'retryOnForbidden' in opts ? opts.retryOnForbidden : true;
         this.debugFunction = 'debugFunction' in opts ? opts.debugFunction : undefined;
         // eslint-disable-next-line

--- a/tests/CoamClient.tests.js
+++ b/tests/CoamClient.tests.js
@@ -63,6 +63,41 @@ describe('CoamClient', function() {
         requestStub = mockRequestResponse('yes!');
     });
 
+    describe('ctor()', () => {
+        let testCases = [
+            {
+                name: 'timeout 0, retryAttempts 0, retryDelayInMs 0',
+                options: {timeout: 0, retryAttempts: 0, retryDelayInMs: 0},
+                expectedTimeout: 0,
+                expectedRetryAttempts: 0,
+                expectedRetryDelayInMs: 0,
+            },
+            {
+                name: 'defaults',
+                options: {},
+                expectedTimeout: 10000,
+                expectedRetryAttempts: 2,
+                expectedRetryDelayInMs: 200,
+            },
+            {
+                name: 'random integer values',
+                options: {timeout: 999, retryAttempts: 888, retryDelayInMs: 777},
+                expectedTimeout: 999,
+                expectedRetryAttempts: 888,
+                expectedRetryDelayInMs: 777,
+            },
+        ];
+        testCases.forEach((testCase) => {
+            it(testCase.name, () => {
+                let client = new CoamClient(testCase.options);
+
+                expect(client.timeout).to.equal(testCase.expectedTimeout);
+                expect(client.retryAttempts).to.equal(testCase.expectedRetryAttempts);
+                expect(client.retryDelayInMs).to.equal(testCase.expectedRetryDelayInMs);
+            });
+        });
+    });
+
     it('buildGroupUrlFromId', function() {
         const baseUrl = 'https://www.example.com';
         const client = new CoamClient({baseUrl});


### PR DESCRIPTION
It was impossible to specify 0 retryAttempts before. Now it is. I've added unit tests for this.

I've upped the version to v0.2.2, so it should go after #22 