### PR TITLE
Change default timeout to 8 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ by the `options` parameter passed in the constructor.
 * _retryOnForbidden_ - A flag specifying if a retry has to be performed in case of 'Forbidden' response. Defaults to 'true'
 * _debugFunction_ - A function to call to provide debug information. Defaults to none.
 * _errorFunction_ - A function to call on error. Defaults to console.err;
-* _timeout_ - A value setting the timeout of the underlying HTTP calls to COAM. Defaults to 10000 (10 seconds). Set it to 0 for no timeout.
+* _timeout_ - A value setting the timeout of the underlying HTTP calls to COAM. Defaults to 8000 (8 seconds). Set it to 0 for no timeout.
 
 ###### Provided methods 
 * buildGroupUrlFromId(groupId)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A thin client for COAM service",
   "main": "./lib/index.js",
   "files": [

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -8,7 +8,7 @@ class CoamClient {
     constructor(options) {
         let opts = options || {};
         this.baseUrl = opts.baseUrl || DEFAULT_BASE_URL;
-        this.timeout = Number.isInteger(opts.timeout) ? opts.timeout : 10000;
+        this.timeout = Number.isInteger(opts.timeout) ? opts.timeout : 8000;
         this.accessToken = opts.accessToken || undefined;
         this.retryAttempts = Number.isInteger(opts.retryAttempts) ? opts.retryAttempts : 2;
         this.retryDelayInMs = Number.isInteger(opts.retryDelayInMs) ? opts.retryDelayInMs : 200;

--- a/tests/CoamClient.tests.js
+++ b/tests/CoamClient.tests.js
@@ -75,7 +75,7 @@ describe('CoamClient', function() {
             {
                 name: 'defaults',
                 options: {},
-                expectedTimeout: 10000,
+                expectedTimeout: 8000,
                 expectedRetryAttempts: 2,
                 expectedRetryDelayInMs: 200,
             },


### PR DESCRIPTION
The default timeout of 10 seconds and default retry of 2x results in a potential duration of 3x 10 seconds = 30 seconds. Many services run behind API Gateway, which has a hard-limit timeout of 29 seconds, resulting in undefined behavior.

Changing the default to 8 seconds, making the default max timeout 24 seconds, still leaving 5 seconds to return an error to the client in case of very long timeouts.

This is mostly to help new services to be based on better defaults while leaving all override options in place.