### PR TITLE
Add wrapper for getUsersWithResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2020.06.18
+### Added
+- Add function `getUsersWithResource` to allow querying the COAM search endpoint for users with a list of permissions to a resource
+
 ## [0.2.4] - 2019.12.06
 ### Added
 - Typescript typings

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ by the `options` parameter passed in the constructor.
 * addResourceToGroup(groupId, resourceType, resourceId)
 * getUserPermissionsForResourceType(principal, resourceType)
 * getUsersWithPermission(resourceType, resourceIdentifier, permission)
+* getUsersWithResource(resourceType, permissionFilters)
 * createGroupWithUser(principalToCreateGroup, principalToAddToGroup, groupName, groupDescription, rolesToAdd, resourcesToAdd)
 
 #### Direct helper functions
@@ -76,6 +77,7 @@ Here is a list of helpers (name + required parameters):
 * **addResourceToGroup** (accessToken, groupId, resourceType, resourceId) 
 * **getUserPermissionsForResourceType** (accessToken, principal, resourceType)
 * **getUsersWithPermission** (accessToken, resourceType, resourceIdentifier, permission)
+* **getUsersWithResource** (accessToken, resourceType, permissionFilters)
 * **createGroupWithUser** (accessToken, principalToCreateGroup, principalToAddToGroup, groupName, groupDescription, rolesToAdd, resourcesToAdd)
 
 **Important**: All helper methods are using the CoamClient class with default settings (see above).  

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,6 +102,17 @@ interface PrincipalGroup {
   is_admin: boolean;
 }
 
+interface ByResourceSearchResult {
+  canonical_principals: CanonicalPrincipalSearchResult[];
+}
+
+interface CanonicalPrincipalSearchResult {
+  canonical_principal: string;
+  resource_type: string;
+  is_client: boolean;
+  permissions: KeyValue<string[]>;
+}
+
 export declare class CoamClient {
   constructor(options: CoamClientOptions);
 
@@ -125,6 +136,7 @@ export declare class CoamClient {
   addResourceToGroup(groupId: string, resourceType: string, resourceId: string): Promise<ResourceArray>;
   getUserPermissionsForResourceType(principal: string, resourceType: string): Promise<ResourceIdentifierPermissions[]>;
   getUsersWithPermission(resourceType: string, resourceIdentifier: string, permission: string): Promise<string[]>;
+  getUsersWithResource(resourceType: string, permissionFilters: string[]): Promise<ByResourceSearchResult>;
   createGroupWithUser(principalToCreateGroup: string, principalToAddToGroup: string, groupName: string, groupDescription: string, rolesToAdd: string, resourcesToAdd: string): Promise<string>;
 }
 
@@ -148,4 +160,5 @@ export declare function removeResourceFromGroup(accessToken: string, groupId: st
 export declare function addResourceToGroup(accessToken: string, groupId: string, resourceType: string, resourceId: string): Promise<ResourceArray>;
 export declare function getUserPermissionsForResourceType(accessToken: string, principal: string, resourceType: string): Promise<ResourceIdentifierPermissions[]>;
 export declare function getUsersWithPermission(accessToken: string, resourceType: string, resourceIdentifier: string, permission: string): Promise<string[]>;
+export declare function getUsersWithResource(accessToken: string, resourceType: string, permissionFilters: string[]): Promise<ByResourceSearchResult>;
 export declare function createGroupWithUser(accessToken: string, principalToCreateGroup: string, principalToAddToGroup: string, groupName: string, groupDescription: string, rolesToAdd: string, resourcesToAdd: string): Promise<string>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A thin client for COAM service",
   "main": "./lib/index.js",
   "files": [

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -436,6 +436,21 @@ class CoamClient {
     }
 
 
+    getUsersWithResource(resourceType, permissionFilters) {
+        let url = this.__buildUrl(`/auth/access-management/v1/search/canonicalPrincipals/byResource?resource_type={{resourceType}}${permissionFilters && permissionFilters.length > 0 ? '&permissionFilter={{commaSeparatedPermissionFilter}}' : ''}`, {
+            resourceType,
+            commaSeparatedPermissionFilter: permissionFilters && permissionFilters.length > 0 && permissionFilters.join(','),
+        });
+
+        let data = this.__config({
+            url: url,
+            method: 'GET',
+        });
+
+        // [{canonical_principal / resource_type / is_client / permissions}]
+        return this.__exec(data);
+    }
+
     async createGroupWithUser(principalToCreateGroup, principalToAddToGroup, groupName, groupDescription, rolesToAdd, resourcesToAdd) {
         let res = await this.createGroup(groupName, groupDescription);
         let groupId = res.id;

--- a/src/coamHelpers.js
+++ b/src/coamHelpers.js
@@ -140,11 +140,18 @@ const getUserPermissionsForResourceType = (accessToken, principal, resourceType)
     return client.getUserPermissionsForResourceType(principal, resourceType);
 };
 
-const getUsersWithPermission = (accessToken, resourceType, resourceIdentifier, permission) => {
+const getUsersWithPermission = (accessToken, resourceType, permissionFilters) => {
     const client = new CoamClient({
         accessToken: accessToken,
     });
-    return client.getUsersWithPermission(resourceType, resourceIdentifier, permission);
+    return client.getUsersWithPermission(resourceType, permissionFilters);
+};
+
+const getUsersWithResource = (accessToken, resourceType, resourceIdentifier, permission) => {
+    const client = new CoamClient({
+        accessToken: accessToken,
+    });
+    return client.getUsersWithResource(resourceType, resourceIdentifier, permission);
 };
 
 const createGroupWithUser = (accessToken, principalToCreateGroup, principalToAddToGroup, groupName, groupDescription, rolesToAdd, resourcesToAdd) => {
@@ -184,6 +191,7 @@ module.exports = {
     getPrincipal,
 
     getUsersWithPermission,
+    getUsersWithResource,
 
     createGroupWithUser,
 };

--- a/tests/CoamClient.tests.js
+++ b/tests/CoamClient.tests.js
@@ -18,6 +18,7 @@ const principal = 'xPrincipal';
 const resourceType = 'xResourceType';
 const resourceIdentifier = 'xResourceIdentifier';
 const permission = 'xPermission';
+const permissionFilters = ['permA', 'permB', 'permC'];
 
 
 function calledOnceWith(requestStub, args, withNoCache = true) {
@@ -556,6 +557,32 @@ describe('CoamClient', function() {
         });
     });
 
+    it('getUsersWithResource', async function() {
+        let client = new CoamClient({accessToken: accessToken});
+
+        // Works when specifying resourceIdentifier
+        await client.getUsersWithResource(resourceType);
+        calledOnceWith(requestStub, {
+            'headers': {
+                'Authorization': `Bearer ${accessToken}`,
+            },
+            'method': 'GET',
+            'url': `/auth/access-management/v1/search/canonicalPrincipals/byResource?resource_type=${resourceType}`,
+        });
+
+        // Works without specifying resourceIdentifier
+        requestStub = mockRequestResponse('yes!');
+        client = new CoamClient({accessToken: accessToken});
+        await client.getUsersWithResource(resourceType, permissionFilters);
+
+        calledOnceWith(requestStub, {
+            'headers': {
+                'Authorization': `Bearer ${accessToken}`,
+            },
+            'method': 'GET',
+            'url': `/auth/access-management/v1/search/canonicalPrincipals/byResource?resource_type=${resourceType}&permissionFilter=${permissionFilters.join('%2C')}`,
+        });
+    });
 
     it('createGroupWithUser', async function() {
         // define the user and group details that we want to use for this test

--- a/tests/coamHelpers.tests.js
+++ b/tests/coamHelpers.tests.js
@@ -26,6 +26,7 @@ describe('COAM Helpers', function() {
         'getPrincipal',
         'findPrincipals',
         'getUsersWithPermission',
+        'getUsersWithResource',
     ].forEach((helperName) => {
         it(`${helperName} method calls appropriate client method`, function() {
             const stubs = {
@@ -51,6 +52,7 @@ describe('COAM Helpers', function() {
                 getPrincipal: sinon.spy(),
                 findPrincipals: sinon.spy(),
                 getUsersWithPermission: sinon.spy(),
+                getUsersWithResource: sinon.spy(),
             };
 
             const fakeCoamClient = function() {


### PR DESCRIPTION
That's a manual test I ran, and works as expected:

```javascript
const CoamClient = require('./src/CoamClient');

let options = {accessToken: '<my token>'};
let client = new CoamClient(options);
client.getUsersWithResource('account', ['read:account-details', 'write:account-details'])
    .then((r) => console.log(JSON.stringify(r, null, 2)));
```