### PR TITLE
make skipCache configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ by the `options` parameter passed in the constructor.
 * _debugFunction_ - A function to call to provide debug information. Defaults to none.
 * _errorFunction_ - A function to call on error. Defaults to console.err;
 * _timeout_ - A value setting the timeout of the underlying HTTP calls to COAM. Defaults to 8000 (8 seconds). Set it to 0 for no timeout.
+* _skipCache_ - A flag specifying if cache should be skipped. Defaults to 'false'
 
 ###### Provided methods 
 * buildGroupUrlFromId(groupId)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coam-client",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "A thin client for COAM service",
   "main": "./lib/index.js",
   "files": [

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -67,8 +67,8 @@ class CoamClient {
     }
 
     __exec(data) {
-        if(this.skipCache && data.method === 'GET') {
-            data.params = data.params ? {...data.params, skipCache: Math.random() } : { skipCache: Math.random() }
+        if (this.skipCache && data.method === 'GET') {
+            data.params = data.params ? Object.assign(data.params, {skipCache: Math.random()}) : {skipCache: Math.random()};
         }
         return this.instance
             .request(data)
@@ -122,7 +122,7 @@ class CoamClient {
 
         let data = this.__config({
             url: url,
-            method: 'GET'
+            method: 'GET',
         });
 
         return this.__exec(data)
@@ -156,7 +156,7 @@ class CoamClient {
             url: groupUrl,
             method: 'GET',
             params: {
-                canonicalize: 'true'
+                canonicalize: 'true',
             },
         });
 
@@ -221,7 +221,7 @@ class CoamClient {
 
         let data = this.__config({
             url: url,
-            method: 'GET'
+            method: 'GET',
         });
 
         return this.__exec(data).then((data) => !!data.groups.find((a) => a.id === '56'));
@@ -298,7 +298,7 @@ class CoamClient {
             method: 'GET',
             params: {
                 q: query,
-                canonicalize: true
+                canonicalize: true,
             },
         });
 
@@ -350,7 +350,7 @@ class CoamClient {
             method: 'GET',
             params: {
                 resource_type: resourceType,
-                resource_identifier: resourceIdentifier
+                resource_identifier: resourceIdentifier,
             },
         });
 

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -16,12 +16,13 @@ class CoamClient {
         this.debugFunction = 'debugFunction' in opts ? opts.debugFunction : undefined;
         // eslint-disable-next-line
         this.errorFunction = 'errorFunction' in opts ? opts.errorFunction : console.error;
+        this.skipCache = 'skipCache' in opts ? opts.skipCache : false;
 
         this.logPrefix = '[CoamClient]';
 
         let validOptions = ['baseUrl', 'accessToken', 'timeout',
             'retryAttempts', 'retryDelayInMs', 'retryOnForbidden',
-            'debugFunction', 'errorFunction'];
+            'debugFunction', 'errorFunction', 'skipCache'];
 
         Object.keys(opts).forEach((passedOption) => {
             if (validOptions.indexOf(passedOption) === -1) {
@@ -66,6 +67,9 @@ class CoamClient {
     }
 
     __exec(data) {
+        if(this.skipCache && data.method === 'GET') {
+            data.params = data.params ? {...data.params, skipCache: Math.random() } : { skipCache: Math.random() }
+        }
         return this.instance
             .request(data)
             .then((response) => {
@@ -118,10 +122,7 @@ class CoamClient {
 
         let data = this.__config({
             url: url,
-            method: 'GET',
-            params: {
-                skipCache: Math.random(),
-            },
+            method: 'GET'
         });
 
         return this.__exec(data)
@@ -155,8 +156,7 @@ class CoamClient {
             url: groupUrl,
             method: 'GET',
             params: {
-                canonicalize: 'true',
-                skipCache: Math.random(),
+                canonicalize: 'true'
             },
         });
 
@@ -221,10 +221,7 @@ class CoamClient {
 
         let data = this.__config({
             url: url,
-            method: 'GET',
-            params: {
-                skipCache: Math.random(),
-            },
+            method: 'GET'
         });
 
         return this.__exec(data).then((data) => !!data.groups.find((a) => a.id === '56'));
@@ -301,8 +298,7 @@ class CoamClient {
             method: 'GET',
             params: {
                 q: query,
-                canonicalize: true,
-                skipCache: Math.random(),
+                canonicalize: true
             },
         });
 
@@ -317,9 +313,6 @@ class CoamClient {
         let data = this.__config({
             url,
             method: 'GET',
-            params: {
-                skipCache: Math.random(),
-            },
         });
         return this.__exec(data);
     }
@@ -357,8 +350,7 @@ class CoamClient {
             method: 'GET',
             params: {
                 resource_type: resourceType,
-                resource_identifier: resourceIdentifier,
-                skipCache: Math.random(),
+                resource_identifier: resourceIdentifier
             },
         });
 

--- a/src/CoamClient.js
+++ b/src/CoamClient.js
@@ -68,7 +68,7 @@ class CoamClient {
 
     __exec(data) {
         if (this.skipCache && data.method === 'GET') {
-            data.params = data.params ? Object.assign(data.params, {skipCache: Math.random()}) : {skipCache: Math.random()};
+            data.params = Object.assign(data.params || {}, {skipCache: Math.random()});
         }
         return this.instance
             .request(data)


### PR DESCRIPTION
We ran into some performance issue due to high number of GET requests which bypassed cache with skipCache query param. Adding a property in the coamClient options so user can control it.